### PR TITLE
RPT-4933 Update raas-client-ktor to 2.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
     implementation("io.ktor:ktor-server-cors:$ktor_version")
-    implementation("jp.co.sutech:raas-client-ktor:2.2.1")
+    implementation("jp.co.sutech:raas-client-ktor:2.2.2")
     implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
 
 }


### PR DESCRIPTION
認証トークンのログ出力を修正した raas-client-ktor 2.2.2 ([RPT-4933](https://sutech.atlassian.net/browse/RPT-4933)) に参照を更新。

⚠️ **2.2.2 の publish (raas-client-ktor#11 merge 後の `gradle publish`) が完了してから merge してください**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPT-4933]: https://sutech.atlassian.net/browse/RPT-4933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ